### PR TITLE
[WIP] ASSETS-48891 Adopt modal dialog support to common Host API in Detail extension

### DIFF
--- a/src/generator-add-web-assets.js
+++ b/src/generator-add-web-assets.js
@@ -125,6 +125,17 @@ class ExtensionWebAssetsGenerator extends Generator {
                     PanelComponentName: panelComponentName
                 }
             );
+
+            const customModals = panel.customModals || [];
+            customModals.forEach((modal) => {
+                const modalComponentName = modal.componentName;
+                this.fs.copyTpl(
+                    this.templatePath(relativeTemplatePath),
+                    this.destinationPath(path.join(this.destFolder, `./src/components/${modalComponentName}.js`)), {
+                        ModalComponentName: modalComponentName
+                    }
+                );
+            });
         })
     }
 }

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -140,10 +140,32 @@ const promptMainMenu = (manifest) => {
 
 // Prompts for panel metadata
 const nestedPanelsPrompts = (manifest, manifestNodeName) => {
-    const questions = [tooltipPrompt(), titlePrompt(), iconPrompt()];
+    // First prompt for basic info
+    const basicQuestions = [tooltipPrompt(), titlePrompt(), iconPrompt()];
 
     return inquirer
-        .prompt(questions)
+        .prompt(basicQuestions)
+        .then((basicAnswers) => {
+            // If modal is needed, prompt for modal details
+            if (basicAnswers.needsModal) {
+                // First get title and type
+                const mandatoryModalQuestions = [
+                    modalTitlePrompt(),
+                    modalTypePrompt()
+                ];
+
+                return inquirer.prompt(mandatoryModalQuestions).then(mandatoryModalAnswers => {
+                    // Only prompt for size if type is 'modal'
+                    if (mandatoryModalAnswers.modalType === 'modal') {
+                        return inquirer.prompt(modalSizePrompt()).then(sizeAnswer => {
+                            return {...basicAnswers, ...mandatoryModalAnswers, ...sizeAnswer};
+                        });
+                    }
+                    return {...basicAnswers, ...mandatoryModalAnswers};
+                });
+            }
+            return basicAnswers;
+        })
         .then((answers) => {
             answers.id = slugify(answers.tooltip, {
                 replacement: '-',  // replace spaces with replacement character, defaults to `-`
@@ -156,6 +178,11 @@ const nestedPanelsPrompts = (manifest, manifestNodeName) => {
             answers.componentName = 'Panel' + answers.id.split('-')
                 .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
                 .join('');
+            if (answers.needsModal) {
+                answers.componentName = 'Modal' + answers.id.split('-')
+                    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+                    .join('');
+            }
             manifest[manifestNodeName] = manifest[manifestNodeName] || [];
             manifest[manifestNodeName].push(answers);
         })
@@ -324,6 +351,51 @@ const iconPrompt = () => {
     };
 }
 
+const modalPrompt = () => {
+    return {
+        type: 'confirm',
+        name: 'needsModal',
+        message: "Do you need to show a modal for the button?",
+        default: false
+    };
+}
+
+const modalTitlePrompt = () => {
+    return {
+        type: 'input',
+        name: 'modalTitle',
+        message: 'Please provide the title for the modal:',
+        validate(answer) {
+            if (!answer.length) {
+                return 'Required.';
+            }
+
+            return true;
+        },
+    };
+}
+
+const modalTypePrompt = () => {
+    return {
+        type: 'list',
+        name: 'modalType',
+        message: 'Please select the type for the modal:',
+        default: 'modal',
+        choices: [
+            'modal',
+            'fullScreen'
+        ],
+    };
+}
+
+const modalSizePrompt = () => {
+    return {
+        type: 'list',
+        name: 'modalSize',
+        message: 'Please select the size for the modal:',
+        choices: ['S', 'M', 'L']
+    };
+}
 // Prompts for action metadata
 const nestedActionPrompts = (manifest, manifestNodeName) => {
     let actionName = 'generic';
@@ -374,7 +446,7 @@ const promptGuideMenu = (manifest) => {
         {
             name: "Go back",
             value: () => {
-                return Promise.resolve(true)
+                return Promise.resolve(true);
             }
         }
     );

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -141,7 +141,7 @@ const promptMainMenu = (manifest) => {
 // Prompts for panel metadata
 const nestedPanelsPrompts = (manifest, manifestNodeName) => {
     // First prompt for basic info
-    const basicQuestions = [tooltipPrompt(), titlePrompt(), iconPrompt()];
+    const basicQuestions = [tooltipPrompt(), titlePrompt(), iconPrompt(), modalPrompt()];
 
     return inquirer
         .prompt(basicQuestions)
@@ -150,6 +150,7 @@ const nestedPanelsPrompts = (manifest, manifestNodeName) => {
             if (basicAnswers.needsModal) {
                 // First get title and type
                 const mandatoryModalQuestions = [
+                    modalButtonLabelPrompt(),
                     modalTitlePrompt(),
                     modalTypePrompt()
                 ];
@@ -179,7 +180,7 @@ const nestedPanelsPrompts = (manifest, manifestNodeName) => {
                 .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
                 .join('');
             if (answers.needsModal) {
-                answers.componentName = 'Modal' + answers.id.split('-')
+                answers.modalComponentName = 'Modal' + answers.id.split('-')
                     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
                     .join('');
             }
@@ -355,8 +356,24 @@ const modalPrompt = () => {
     return {
         type: 'confirm',
         name: 'needsModal',
-        message: "Do you need to show a modal for the button?",
+        message: "Do you need to show a modal with a button?",
         default: false
+    };
+}
+
+// Helper prompts for the open for opening a modal dialog
+const modalButtonLabelPrompt = () => {
+    return {
+        type: 'input',
+        name: 'label',
+        message: 'Please provide label for the button:',
+        validate(answer) {
+            if (!answer.length) {
+                return 'Required.';
+            }
+
+            return true;
+        },
     };
 }
 

--- a/src/templates/_shared/stub-modal.ejs
+++ b/src/templates/_shared/stub-modal.ejs
@@ -1,0 +1,54 @@
+/*
+ * <license header>
+ */
+
+import React, { useState, useEffect } from 'react';
+import { attach } from '@adobe/uix-guest';
+import {
+  Flex,
+  Provider,
+  defaultTheme,
+  Link,
+  Text,
+  ButtonGroup,
+  Button,
+  View
+} from '@adobe/react-spectrum';
+
+import { extensionId } from './Constants';
+
+export default function <%- ModalComponentName %>() {
+  // Fields
+  const [guestConnection, setGuestConnection] = useState();
+  const [colorScheme, setColorScheme] = useState('light');
+
+  useEffect(() => {
+    (async () => {
+      const guestConnection = await attach({ id: extensionId });
+      setGuestConnection(guestConnection);
+
+      const { colorScheme } = await guestConnection.host.theme.getThemeInfo();
+      setColorScheme(colorScheme);
+    })()
+  }, []);
+
+  function closeDialog() {
+    guestConnection.host.modal.closeDialog();
+  }
+
+  return (
+  <Provider theme={defaultTheme} colorScheme={colorScheme} height={'100vh'}>
+    <View>
+      <View>
+        <Text>Please visit <Link href="https://developer.adobe.com/uix/docs/">UI Extensibility documentation</Link> to get started.</Text>
+
+        <Flex justifyContent="center" marginTop="size-400">
+          <ButtonGroup>
+            <Button variant="primary" onPress={() => closeDialog()}>Close</Button>
+          </ButtonGroup>
+        </Flex>
+      </View>
+    </View>
+  </Provider>
+  );
+}


### PR DESCRIPTION
Adopt modal dialog support to common Host API in Detail extension

## Description

Extend existing template to prompt user for the need to open a custom dialog.
If the user responds with `yes` then prompt for a button label, dialog title, type and size and generate the required UI content 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/ASSETS-48891

## Motivation and Context

Provide convenience to generate boilerplate code for opening custom modal dialogs from detail side panels
Reduce learning curve for developer to implement the same
Align with the support of custom modal dialogs that will be part of the browse extension

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
