### PR TITLE
ASSETS-66258 Updated to v0.2.0 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/aem-assets-details-ext-tpl",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.js",
   "description": "Asset Details extension template for the AEM Assets View",
   "engines": {

--- a/src/templates/_shared/stub-extension-registration.ejs
+++ b/src/templates/_shared/stub-extension-registration.ejs
@@ -13,21 +13,27 @@ function ExtensionRegistration() {
       id: extensionId,
       methods: {
         detailSidePanel: {
-          getPanels() {
+          getPanels({ resource }) {
             // YOUR SIDE PANELS CODE SHOULD BE HERE
             return [
               <%_ if (extensionManifest.detailsSidePanels) { -%>
                 <%_ extensionManifest.detailsSidePanels.forEach((panel) => { -%>
               {
-                'id': '<%- panel.id %>',
-                'tooltip': '<%- panel.tooltip %>',
-                'icon': '<%- panel.icon %>',
-                'title': '<%- panel.title %>',
-                'contentUrl': '/#<%- panel.id %>',
-                'reloadOnThemeChange': 'true',
+                id: '<%- panel.id %>',
+                tooltip: '<%- panel.tooltip %>',
+                icon: '<%- panel.icon %>',
+                title: '<%- panel.title %>',
+                contentUrl: '/#<%- panel.id %>',
+                reloadOnThemeChange: true,
               },
               <%_ })} -%>
             ];
+          },
+          getHiddenBuiltInPanels({ resource }) {
+            return [];
+          },
+          overrideBuiltInPanel({ panelId, resource }) {
+            return null;
           },
         },
         headerMenu: {

--- a/test/generator-add-web-assets.test.js
+++ b/test/generator-add-web-assets.test.js
@@ -97,27 +97,27 @@ function assertCodeContent(extensionManifest) {
     detailsSidePanels.forEach((panel) => {
         assert.fileContent(
             `${webSrcFolder}/src/components/ExtensionRegistration.js`,
-            `'id': '${panel.id}'`
+            `id: '${panel.id}'`
         );
         assert.fileContent(
             `${webSrcFolder}/src/components/ExtensionRegistration.js`,
-            `'tooltip': '${panel.tooltip}'`
+            `tooltip: '${panel.tooltip}'`
         );
         assert.fileContent(
             `${webSrcFolder}/src/components/ExtensionRegistration.js`,
-            `'icon': '${panel.icon}'`
+            `icon: '${panel.icon}'`
         );
         assert.fileContent(
             `${webSrcFolder}/src/components/ExtensionRegistration.js`,
-            `'title': '${panel.title}'`
+            `title: '${panel.title}'`
         );
         assert.fileContent(
             `${webSrcFolder}/src/components/ExtensionRegistration.js`,
-            `'contentUrl': '/#${panel.id}'`
+            `contentUrl: '/#${panel.id}'`
         );
         assert.fileContent(
             `${webSrcFolder}/src/components/ExtensionRegistration.js`,
-            `'reloadOnThemeChange': 'true'`
+            'reloadOnThemeChange: true'
         );
 
         const panelFileName = 'Panel' + panel.id.substring(0, 1).toUpperCase() + panel.id.substring(1);
@@ -135,6 +135,23 @@ function assertCodeContent(extensionManifest) {
             `export default function ${panelFileName}()`
         );
     });
+
+    assert.fileContent(
+        `${webSrcFolder}/src/components/ExtensionRegistration.js`,
+        'getPanels({ resource })'
+    );
+    assert.fileContent(
+        `${webSrcFolder}/src/components/ExtensionRegistration.js`,
+        `getHiddenBuiltInPanels({ resource }) {
+            return [];
+          }`
+    );
+    assert.fileContent(
+        `${webSrcFolder}/src/components/ExtensionRegistration.js`,
+        `overrideBuiltInPanel({ panelId, resource }) {
+            return null;
+          }`
+    );
 
     // for headerMenu
     assert.fileContent(


### PR DESCRIPTION
Updated to v0.2.0 
* added methods to hide and override panels for details extension

## Description

`aem-assets-details-ext-tpl` should now generate stubs for 

```
getHiddenBuiltInPanels({ resource }) {
        return [];
    },

overrideBuiltInPanel({ panelId, resource }) {
        return null; // Use built-in panel
    }
```

## Related Issue
ASSETS-66258
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

extensions implementing the `detailSidePanel` namespace have the option to implement two new methods
* getHiddenBuiltInPanels
* overrideBuiltInPanel

## How Has This Been Tested?

An extension was created providing the path to the extension
`aio app init DetailsTest_v2 -t <path>/aem-assets-details-ext-tpl`

The extension was started and tested
* getHiddenBuiltInPanels returned an array ['comment', 'version]
* overrideBuiltInPanel


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
